### PR TITLE
Fix: Make return value behavior consistent for both platforms

### DIFF
--- a/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheet.java
+++ b/android/src/main/java/com/clipsub/rnbottomsheet/RNBottomSheet.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 public class RNBottomSheet extends ReactContextBaseJavaModule {
 
+    private boolean isResponsePositive;
     private boolean isOpened;
     private Callback shareSuccessCallback;
     private Callback shareFailureCallback;
@@ -41,6 +42,7 @@ public class RNBottomSheet extends ReactContextBaseJavaModule {
         if (this.isOpened) return;
 
         this.isOpened = true;
+        this.isResponsePositive = false;
 
         ReadableArray optionArray = options.getArray("options");
         final Integer cancelButtonIndex = options.getInt("cancelButtonIndex");
@@ -75,8 +77,10 @@ public class RNBottomSheet extends ReactContextBaseJavaModule {
         builder.listener(new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
+                RNBottomSheet.this.isResponsePositive = (which != cancelButtonIndex);
                 dialog.dismiss();
-                if (which != cancelButtonIndex) {
+
+                if (RNBottomSheet.this.isResponsePositive) {
                     onSelect.invoke(which);
                 }
             }
@@ -86,6 +90,12 @@ public class RNBottomSheet extends ReactContextBaseJavaModule {
             @Override
             public void onDismiss(DialogInterface dialog) {
                 RNBottomSheet.this.isOpened = false;
+
+                // For consistency with BottomSheetIos behavior, return the index of the cancel
+                // option upon negative dismissal (e.g. Cancel button, or Android back button)
+                if (!RNBottomSheet.this.isResponsePositive) {
+                    onSelect.invoke(cancelButtonIndex);
+                }
             }
         });
 


### PR DESCRIPTION
On Android, the code does not return when the user cancels. This is an issue, since:
- On the JS side, it's impossible to detect if the user cancelled the sheet
- It's impossible to write code to "wait" until the user responds
- This behavior is inconsistent with how it works on iOS

**Test plan**

- [x] Try it out here: https://github.com/Instawork/mobile/pull/742